### PR TITLE
Python 3.5 compatible string formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ script:
 cache: pip
 matrix:
   include:
+    - python: '3.5'
     - python: '3.6'
-    - python: 3.7-dev
-  allow_failures:
-    - python: 3.7-dev
+    - python: '3.7'

--- a/Pipfile
+++ b/Pipfile
@@ -18,4 +18,4 @@ codecov = "*"
 pytest-cov = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "3.5"

--- a/pwnedapi/Password.py
+++ b/pwnedapi/Password.py
@@ -24,7 +24,7 @@ class Password():
     # Hashed need to be encoded before sending
     HASH_ENCODING = "utf-8"
 
-    USER_AGENT = f"pwnedapi v{__version__}"
+    USER_AGENT = "pwnedapi v{}".format(__version__)
 
     DEFAULT_REQUEST_HEADERS = {
         "User-Agent": USER_AGENT

--- a/pwnedapi/tests/scanner_test.py
+++ b/pwnedapi/tests/scanner_test.py
@@ -47,7 +47,7 @@ def test_export_as(tempfile):
 def test_scan_empty_file(emptyfile):
     scanner = Scanner()
 
-    with pytest.raises(OSError, message=f"File {emptyfile} is empty."):
+    with pytest.raises(OSError, message="File {} is empty.".format(emptyfile)):
         scanner.scan(emptyfile)
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ class UploadCommand(Command):
         os.system("twine upload dist/*")
 
         self.status("Pushing git tags...")
-        os.system(f"git tag v{about['__version__']}")
+        os.system("git tag v{}".format(about['version']))
         os.system("git push --tags")
 
         sys.exit()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ DESCRIPTION = "Library for easily interfacing with Have I Been Pwned API v2."
 URL = "https://github.com/nikoheikkila/pwnedapi"
 EMAIL = "yo@nikoheikkila.fi"
 AUTHOR = "Niko Heikkilä"
-REQUIRES_PYTHON = ">=3.6.0"
+REQUIRES_PYTHON = ">=3.5.0"
 VERSION = None
 
 # Required packages
@@ -43,7 +43,7 @@ class UploadCommand(Command):
     @staticmethod
     def status(s):
         """Bolds given text"""
-        print(f"\033[1m{s}\033[0m")
+        print("\033[1m{}\033[0m".format(s))
 
     def initialize_options(self):
         pass
@@ -59,7 +59,7 @@ class UploadCommand(Command):
             pass
         
         self.status("Building source and wheel (universal) distribution")
-        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
+        os.system("{} setup.py sdist bdist_wheel --universal".format(sys.executable))
 
         self.status("Uploading the package to PyPi via Twine...")
         os.system("twine upload dist/*")
@@ -91,7 +91,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],


### PR DESCRIPTION
When deploying a flask project implementing pwnedapi on the production server running debian stable (stretch), pwnedapi failed to install via pip. Version 0.3.0 failed, and version 0.4.0 was not available due to minimum python version 3.6. Debian stretch still ships with python 3.5 only. 
Since only string formatting is affected, and there is only one instance in the actual Password class, I decided to add python 3.5 compatibility by replacing f"{}" with "{}".format() rather than messing with the python version on the production servers. Less elegant though, but might help others wanting to use this lib.