### PR TITLE
Support Python 3.7 in Travis using Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
+sudo: required
+dist: xenial
 python:
   - 3.5
   - 3.6
+  - 3.7
 
 install: make
 


### PR DESCRIPTION
Let's make Travis use Xenial distribution and sudo mode for enabling Python 3.7 checks. This is not the _most optimal_ solution but seems to work (and I don't need to bother using `pyenv` to switch back and forth Python versions anymore). 😛

See https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905 for used workaround